### PR TITLE
Update generateDownloadScript.js

### DIFF
--- a/static/src/js/util/files/generateDownloadScript.js
+++ b/static/src/js/util/files/generateDownloadScript.js
@@ -19,7 +19,7 @@ export const generateDownloadScript = (granuleLinks, retrievalCollection, earthd
   let { edlHost } = getEarthdataConfig(earthdataEnvironment)
   edlHost = url.parse(edlHost).host
 
-  return `#!/bin/sh
+  return `#!/bin/bash
 
 GREP_OPTIONS=''
 


### PR DESCRIPTION
# Overview

Updated to point to bash instead of sh since some of the other commands in the script are bash specific such as "function", "read", etc.  I tested this on Ubuntu and it only worked correctly with the bash statement and without the statement all together.

### What is the feature?

The issue is that be default this script runs sh instead of bash.  Some of the methods used in the download script are not compatible with sh.

### What is the Solution?

Changes the default shell to point to bash instead of sh.

### What areas of the application does this impact?

This fix only affects the generation of the download script.

# Testing

### Reproduction steps

Tested with ubuntu linux.

1. Run the script with sh and see that ubuntu complains.
2. Run the script with the change so that it loads bash and see that ubuntu doesn't complain.
